### PR TITLE
feat: switch to githack html viewer

### DIFF
--- a/lib/outliers.py
+++ b/lib/outliers.py
@@ -701,8 +701,7 @@ def loop_over_everything(
         Path to jinja2 html template file
     """
     urlprefix = (
-        "https://htmlpreview.github.io/?"
-        + "https://raw.githubusercontent.com/ebmdatalab/outliers/master/"
+        "https://raw.githack.com/ebmdatalab/outliers/master/"
     )
     toc = MarkdownToC(urlprefix)
 


### PR DESCRIPTION
While preparing #19  it was revealed that the links to openprescribing's analyse page were being corrupted by the htmlpreview service previously used (despite the correct URL being present in the raw html source). 

Tests with [githack](https://raw.githack.com/) revealed it to be a suitable alternative without this problem